### PR TITLE
Edit and formatted vpn_dashboard.md for clarity

### DIFF
--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -54,9 +54,9 @@ These VPN clients use WireGuard, a VPN protocol. To set up the above clients or 
 
 ## Primary Tunnel
 
-The Primary Tunnel is a preset VPN tunnel where you can customize the tunnel rule <!-- Opt for tunnel rule instead of traffic rule because it matches with UI label "VPN Tunnel" and "Add Tunnel", which are where rules are created. --> by setting three factors: 
+The Primary Tunnel is a preset VPN tunnel where you can customize the tunnel rule <!-- Changed to "tunnel rule" for consistency. Also because it matches with UI label "VPN Tunnel" and "Add Tunnel", which are where rules are created. --> by setting three factors: 
 
-- **Traffic Originating From** (i.e. traffic of which device should use this rule)
+- **Traffic Originating From** (i.e. traffic of which device should use this tunnel rule)
 - **Execute** (i.e. to use VPN or not use VPN)
 - **Travelling To** (i.e. to which target does the traffic travels through this tunnel)
 
@@ -64,11 +64,13 @@ The Primary Tunnel is a preset VPN tunnel where you can customize the tunnel rul
 
 ### Traffic Originating From
 
-Click the greyed-out box under **Traffic Originating From**, select the device that you want to apply this rule to.
+1. Click the greyed-out box under **Traffic Originating From**. <!-- Added ordered lists for instructions so that each image has a corresponding caption. -->
 
-![traffic from 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/traffic_from_1.png){class="glboxshadow"}
-
-![traffic from 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/traffic_from_2.png){class="glboxshadow"}
+    ![traffic from 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/traffic_from_1.png){class="glboxshadow"}
+   
+2. Select the device that you want to apply this rule to.
+   
+    ![traffic from 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/traffic_from_2.png){class="glboxshadow"}
 
 - **All Clients**: Traffic from all devices will apply this rule.
 
@@ -88,11 +90,13 @@ Click the greyed-out box under **Traffic Originating From**, select the device t
 
 ### Execute
 
-Click the greyed-out box under **Execute**, select the action you want to perform on this rule.
+1. Click the greyed-out box under **Execute**. 
 
-![execute 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/execute_1.png){class="glboxshadow"}
+    ![execute 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/execute_1.png){class="glboxshadow"}
 
-![execute 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/execute_2.png){class="glboxshadow"}
+2. Select the action you want to perform on this rule.
+   
+    ![execute 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/execute_2.png){class="glboxshadow"}
 
 - **Execute**: Use VPN or Not Use VPN.
 - **Auto-select Configuration**: When enabled, the tunnel automatically selects available VPN configurations <!-- Changed to "VPN configurations" to be consistent with this setting name. Understand that "profiles" refers to saved VPN configurations. However, the term "profile" has not been introduced in this guide, thus it's substitutued to avoid confusion. --> to connect.
@@ -100,23 +104,25 @@ Click the greyed-out box under **Execute**, select the action you want to perfor
 
 ### Travelling To
 
-Click the greyed-out box under **Travelling To**, select the target that the traffic travels to through this tunnel.
+1. Click the greyed-out box under **Travelling To**. 
 
-![Travel to 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_1.png){class="glboxshadow"}
+    ![Travel to 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_1.png){class="glboxshadow"}
 
-![Travel to 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_2.png){class="glboxshadow"}
+2. Select the target that the traffic travels to through this tunnel.
+
+    ![Travel to 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_2.png){class="glboxshadow"}
 
 - **All targets**: Traffic through this tunnel will travel to all destinations.
 
     ![all targets](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_3.png){class="glboxshadow gl-80-desktop"}
 
-- **Specified Domain / IP List**: Traffic through this tunnel will travel to specified Domain / IP. 
+- **Specified Domain / IP List**: Traffic through this tunnel will travel to a specified Domain / IP. 
 
     Manually input the specified Domain / IP.
 
     ![specified domain/IP manual](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_4.png){class="glboxshadow gl-80-desktop"}
 
-    Or switch the Input Mode from Manual to Subscription URL and input URL Link. 
+    Or switch the **Input Mode** from **Manual** to **Subscription URL** and input URL Link. 
 
     ![specified domain/IP subscription](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_5.png){class="glboxshadow gl-80-desktop"}
 
@@ -131,7 +137,7 @@ Click the greyed-out box under **Travelling To**, select the target that the tra
 
     ![exclude specified domain/IP](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_6.png){class="glboxshadow gl-80-desktop"}
 
-    Or switch the Input Mode from Manual to Subscription URL and input URL Link. 
+    Or switch the **Input Mode** from **Manual** to **Subscription URL** and input URL Link. 
 
     !!! Note
         - If you select Subscribe URL, the domain name or IP in the URL is automatically updated every day. 
@@ -140,7 +146,7 @@ Click the greyed-out box under **Travelling To**, select the target that the tra
 
 ### Tunnel Settings
 
-Click the cog icon next to the Primary Tunnel, you can rename the tunnel, change tunnel settings or delete the tunnel. 
+Click the cog icon next to **Primary Tunnel**, you can rename the tunnel, change tunnel settings or delete the tunnel. 
 
 ![tunnel settings](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/tunnel_settings.png){class="glboxshadow"}
 
@@ -148,14 +154,14 @@ Click the cog icon next to the Primary Tunnel, you can rename the tunnel, change
 
 ![tunnel options](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/tunnel_options.png){class="glboxshadow gl-80-desktop"}
 
-- **Services from GL.iNet Use VPN**: If this option is enabled, GoodCloud, DDNS, and rtty services will use VPN tunnels to send packets. Note that these services normally need to use the real IP address of the device, otherwise operations may fail.
-- **Remote Access LAN**: If this option is enabled, resources inside the LAN subnet can be accessed through the VPN tunnel.
-- **IP Masquerading**: If this option is enabled, when client devices on LAN send their IP packets, the router replaces the source IP address with its own address and then forwards it to the VPN tunnel.
-- **MTU**: The MTU you set for the instance here will overwrite the MTU item in the configuration file.
+- **Services from GL.iNet Use VPN**: When enabled, GoodCloud, DDNS, and rtty services will use VPN tunnels. Note that these services normally need to use the real IP address of the device, enabling this option may affect operation. <!-- Not sure if the original phrasing is intentionally less direct -->
+- **Remote Access LAN**: When enabled, devices connected to the VPN tunnel can reach other devices (e.g. computers, printers) on your local network (LAN).
+- **IP Masquerading**: When enabled, your LAN devices' outgoing traffic will be sent through the VPN using router's IP address instead of their own.
+- **MTU (Maximum Transmission Unit)**: Set your own MTU for this tunnel, it will override the MTU defined in the configuration file. Leave blank to use the system default value. <!-- Consider reccomending values: e.g. "Reccomended 1300-1500 for WireGuard, 1300-1500 for OpenVPN". Also consider adding link to learn more about defining MTU. -->
 
 ## Add Tunnel
 
-Apart from the preset Primary Tunnel, you can add tunnels to achieve multiple VPN instances.
+Apart from the preset **Primary Tunnel**, you can add tunnels to achieve multiple VPN instances.
 
 ![add tunnels](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/add_tunnel.png){class="glboxshadow"}
 
@@ -163,31 +169,31 @@ After adding a tunnel, the VPN Dashboard page will display the **Priority** opti
 
 ![priority 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/priority_1.png){class="glboxshadow"}
 
-By default, the preset Primary Tunnel will have the highest priority, followed by other manual-added tunnel(s).
+By default, the preset **Primary Tunnel** will have the highest priority, followed by other manual-added tunnel(s).
 
-The built-in Non VPN Tunnel will be locked as a basic tunnel with lowest priority, to ensure local network connectivity.
+The built-in **Non-VPN Tunnel** will be locked as a basic tunnel with lowest priority, to ensure local network connectivity.
 
 ![priority 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/priority_2.png){class="glboxshadow"}
 
-Press and hold the three-line icon on the right to drag the tunnels for sorting.
+Click and hold the three-line icon on the right to drag the tunnels for sorting.
 
 ## Non-VPN Tunnel
 
-The Non-VPN Tunnel is a basic network tunnel with lowest priority. It is unchangeable and cannot be deleted. 
+The **Non-VPN Tunnel** is a basic network tunnel with lowest priority. It is unchangeable and cannot be deleted. 
 
 ![non-vpn tunnel](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/non_vpn_tunnel.png){class="glboxshadow"}
 
-It is actually a local network tunnel that is mutually exclusive with the VPN tunnel.
+It is a local network tunnel that is mutually exclusive with the VPN tunnel, traffic will go through one or the other, not both.
 
 When there are multiple tunnels, the router transmits traffic in the following order:
 
-- When the tunnel with the highest priority is enabled, the traffic that conforms to the tunnel rule will be transmitted according to the set execute action and targets. 
+1. When the tunnel with the highest priority is enabled, the traffic that conforms to the tunnel rule will be transmitted according to the set execute action and targets. 
 
-- For the traffic that does not conform to the tunnel rule of the highest priority, it will automatically be matched to the tunnel rule of the second highest priority. 
+2. For the traffic that does not conform to the tunnel rule of the highest priority, it will automatically be matched to the tunnel rule of the second highest priority. 
 
-- If it still does not match, it will continue to be matched against the next lower priority rule, and so on, until it is matched to the Non-VPN Tunnel with the lowest priority.
+3. If it still does not match, it will continue to be matched against the next lower priority rule, and so on, until it is matched to the Non-VPN Tunnel with the lowest priority.
 
-You can disable the Non-VPN Tunnel if needed. 
+You can disable the **Non-VPN Tunnel** if needed. 
 
 **Note**: Non-VPN tunnelling ensures that traffic not passing through the above tunnels can still connect to the Internet. If disabled, it will drop any remaining traffic.
 

--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -127,7 +127,7 @@ The Primary Tunnel is a preset VPN tunnel where you can customize the tunnel rul
     ![specified domain/IP subscription](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_5.png){class="glboxshadow gl-80-desktop"}
 
     !!! Note
-        - If you select Subscribe URL, the domain name or IP in the URL is automatically updated every day. 
+        - If you select **Subscribe URL**, the domain name or IP in the URL is automatically updated every day. 
 
         - Make sure to enter the correct URL. The URL detection will identify the correctness of the domain name or IP address. [Learn More](../tutorials/how_to_configure_domain_and_ip_filtering_rules_for_glinet_routers_via_an_online_text_file.md){target="_blank"}
 
@@ -140,7 +140,7 @@ The Primary Tunnel is a preset VPN tunnel where you can customize the tunnel rul
     Or switch the **Input Mode** from **Manual** to **Subscription URL** and input URL Link. 
 
     !!! Note
-        - If you select Subscribe URL, the domain name or IP in the URL is automatically updated every day. 
+        - If you select **Subscribe URL**, the domain name or IP in the URL is automatically updated every day. 
 
         - Make sure to enter the correct URL. The URL detection will identify the correctness of the domain name or IP address. [Learn More](../tutorials/how_to_configure_domain_and_ip_filtering_rules_for_glinet_routers_via_an_online_text_file.md){target="_blank"}
 

--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -157,11 +157,11 @@ Click the cog icon next to **Primary Tunnel**, you can rename the tunnel, change
 - **Services from GL.iNet Use VPN**: When enabled, GoodCloud, DDNS, and rtty services will use VPN tunnels. Note that these services normally need to use the real IP address of the device, enabling this option may affect operation. <!-- Not sure if the original phrasing is intentionally less direct -->
 - **Remote Access LAN**: When enabled, devices connected to the VPN tunnel can reach other devices (e.g. computers, printers) on your local network (LAN).
 - **IP Masquerading**: When enabled, your LAN devices' outgoing traffic will be sent through the VPN using router's IP address instead of their own.
-- **MTU (Maximum Transmission Unit)**: Set your own MTU for this tunnel, it determines the largest size of the data packet travelling through your network. Leave blank to use the system default value. <!-- Consider reccomending values: e.g. "Reccomended 1300-1500 for WireGuard, 1300-1500 for OpenVPN". Also consider adding link to learn more about defining MTU. -->
+- **MTU (Maximum Transmission Unit)**: Set your own MTU for this tunnel, it determines the largest size of the data packet travelling through your network. Leave as blank to use the system default value. <!-- Consider reccomending values: e.g. "Reccomended 1300-1500 for WireGuard, 1300-1500 for OpenVPN". Also consider adding link to learn more about defining MTU. -->
 
 ## Add Tunnel
 
-Apart from the preset **Primary Tunnel**, you can add tunnels to achieve multiple VPN instances.
+Apart from the preset **Primary Tunnel**, you can add tunnels to achieve multiple VPN tunnels. <!-- instance > tunnel for consistency-->
 
 ![add tunnels](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/add_tunnel.png){class="glboxshadow"}
 

--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -31,7 +31,7 @@ The VPN dashboard consists of the following parts, marked in the figure below.
 
 ## Navigating to the VPN Dashboard
 
-Open the web Admin Panel, on the left side bar, select **VPN** -> **VPN Dashboard**. <!-- Use bold to mark items/terms on the UI-->
+Open the web Admin Panel, on the left side bar, select **VPN** -> **VPN Dashboard**. 
 
 ![admin panel of gl-axt1800](https://static.gl-inet.com/docs/router/en/4/tutorials/first_time_setup/admin_panel_gl-axt1800.png){class="glboxshadow"}
 

--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -1,6 +1,6 @@
 # VPN Dashboard
 
-GL.iNet routers include a dedicated VPN Dashboard that provides a centralized interface for managing your VPN connections. You can use it to set up and monitor both VPN client and server configurations. The VPN Dashboard allows you to route your internet traffic through encrypted tunnels, helping protect your online privacy, bypass regional restrictions, and access remote networks. 
+GL.iNet routers include a dedicated VPN Dashboard that provides a centralized interface for managing your VPN connections. You can use it to set up and monitor VPN clients and server configurations. The VPN Dashboard allows you to route your internet traffic through encrypted tunnels, helping protect your online privacy, bypass regional restrictions, and access remote networks. 
 
 This guide walks you through the key features of the VPN Dashboard and shows you how to configure, monitor, and optimize your VPN connections.
 
@@ -10,12 +10,13 @@ This guide walks you through the key features of the VPN Dashboard and shows you
 
     This guide is based on firmware v4.8. If you are using an earlier firmware version, please visit [here](vpn_dashboard_v4.7.md).
 
-<!-- Removed "This page visually displays VPN status and settings through graphics." and '[vpn dashboard unmarked.png]' Reason: redundant -->
+<!-- Removed "This page visually displays VPN status and settings through graphics.", "[vpn dashboard unmarked.png]" and "This guide will introduce to you one by one." Reason: redundant -->
 
 ### Contents
 
-The VPN dashboard mainly consists of the following parts, marked in the figure below.
+The VPN dashboard consists of the following parts, marked in the figure below.
 
+1. [Navigating to the VPN Dashboard](#navigating-to-the-vpn-dashboard)
 1. [VPN Setup Wizard](#vpn-setup-wizard)
 2. [Primary Tunnel](#primary-tunnel)
     3. [Traffic Originating From](#traffic-originating-from)
@@ -28,37 +29,42 @@ The VPN dashboard mainly consists of the following parts, marked in the figure b
 </br>
 ![vpn dashboard marked](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/vpn_dashboard_2.png){class="glboxshadow"}
 
-This guide will introduce to you one by one.
-
 ## Navigating to the VPN Dashboard
 
-Access to web Admin Panel, on the left side -> VPN -> VPN Dashboard. 
+Open the web Admin Panel, on the left side bar, select **VPN** -> **VPN Dashboard**. <!-- Use bold to mark items/terms on the UI-->
+
+![admin panel of gl-axt1800](https://static.gl-inet.com/docs/router/en/4/tutorials/first_time_setup/admin_panel_gl-axt1800.png){class="glboxshadow"}
+
+<!-- This image is a placeholder. For easier navigation, the "VPN" dropdown should be expanded, "VPN Dashboard" is highlighted in a red box. -->
 
 ## VPN Setup Wizard
 
-There is no configuration available for VPN Tunnel by default. Please click on VPN Setup Wizard at the upper left, which can help you set up the WireGuard VPN quickly.
+There is no default configuration for VPN tunnels. Click on the VPN Setup Wizard icon at the upper-left corner to quickly set one up. 
 
-![vpn wizard 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/vpn_wizard_1.png){class="glboxshadow"}
+<!-- Changed wording to be short, direct and more command-like. -->
+<!-- Removed "WireGuard VPN" to avoid confusion between VPN protocols and VPN clients. -->
 
-The VPN Setup Wizard is only for AzireVPN, Mullvad, PIA, Surfshark, NordVPN, Hide.me and IPVanish. Configuring the VPN may take a few minutes.
+![vpn wizard 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/vpn_wizard_1.png){class="glboxshadow"} <!-- To maintain consistency, consider highlighting the icon with a red box. -->
+
+The VPN Setup Wizard allows you to set up the following VPN clients: AzireVPN, Mullvad, PIA, Surfshark, NordVPN, Hide.me and IPVanish. Configuring the VPN may take a few minutes.
 
 ![vpn wizard 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/vpn_wizard_2.png){class="glboxshadow"}
 
-For other vpn providers, skip the wizard and go to [OpenVPN Client](openvpn_client.md){target="_blank"} / [WireGuard Client](wireguard_client.md){target="_blank"} to set up VPN manually. 
+These VPN clients use WireGuard, a VPN protocol. To set up the above clients or other WireGuard clients, go to [WireGuard Client](wireguard_client.md){target="_blank"}. <!-- I intend to direct users to the "WireGuard Client" section, since it has follow-up instructions for setting up clients in the Wizard. I assume a separate section is created to avoid bloat in this guide. --> To set up OpenVPN clients, go to [OpenVPN Client](openvpn_client.md){target="_blank"}. <!-- By only listing the two, I'm assuming other open-source protocols like SoftEther are not supported.-->
 
 ## Primary Tunnel
 
-The Primary Tunnel is a preset tunnel where you can customize the traffic rule by setting three factors: 
+The Primary Tunnel is a preset VPN tunnel where you can customize the tunnel rule <!-- Opt for tunnel rule instead of traffic rule because it matches with UI label "VPN Tunnel" and "Add Tunnel", which are where rules are created. --> by setting three factors: 
 
-- Traffic Originating From (i.e. traffic of which device should use this rule)
-- Execute (i.e. use VPN or not use VPN)
-- Travelling To (i.e. to which target does the traffic travels through this tunnel)
+- **Traffic Originating From** (i.e. traffic of which device should use this rule)
+- **Execute** (i.e. to use VPN or not use VPN)
+- **Travelling To** (i.e. to which target does the traffic travels through this tunnel)
 
 ![primary tunnel](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/primary_tunnel.png){class="glboxshadow"}
 
 ### Traffic Originating From
 
-Click the greyed-out box under Traffic Originating From, select the device that you want to apply this rule to.
+Click the greyed-out box under **Traffic Originating From**, select the device that you want to apply this rule to.
 
 ![traffic from 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/traffic_from_1.png){class="glboxshadow"}
 
@@ -82,19 +88,19 @@ Click the greyed-out box under Traffic Originating From, select the device that 
 
 ### Execute
 
-Click the greyed-out box under Execute, select the action you want to perform on this rule.
+Click the greyed-out box under **Execute**, select the action you want to perform on this rule.
 
 ![execute 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/execute_1.png){class="glboxshadow"}
 
 ![execute 2](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/execute_2.png){class="glboxshadow"}
 
 - **Execute**: Use VPN or Not Use VPN.
-- **Auto-select Configuration**: When this option is enabled, the tunnel automatically selects available profiles to connect.
-- **Kill Switch**: Enable this feature to block traffic that matches this rule but is not tunneled, with higher priority than other VPN tunnel rules.
+- **Auto-select Configuration**: When enabled, the tunnel automatically selects available VPN configurations <!-- Changed to "VPN configurations" to be consistent with this setting name. Understand that "profiles" refers to saved VPN configurations. However, the term "profile" has not been introduced in this guide, thus it's substitutued to avoid confusion. --> to connect.
+- **Kill Switch**:When enabled, this feature blocks any matching traffic that isn’t sent through the VPN tunnel. This feature has higher priority over other tunnel rules. <!-- Clarified language. -->
 
 ### Travelling To
 
-Click the greyed-out box under Travelling To, select the target that the traffic travels to through this tunnel.
+Click the greyed-out box under **Travelling To**, select the target that the traffic travels to through this tunnel.
 
 ![Travel to 1](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/travel_to_1.png){class="glboxshadow"}
 

--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -100,7 +100,7 @@ The Primary Tunnel is a preset VPN tunnel where you can customize the tunnel rul
 
 - **Execute**: Use VPN or Not Use VPN.
 - **Auto-select Configuration**: When enabled, the tunnel automatically selects available VPN configurations <!-- Changed to "VPN configurations" to be consistent with this setting name. Understand that "profiles" refers to saved VPN configurations. However, the term "profile" has not been introduced in this guide, thus it's substitutued to avoid confusion. --> to connect.
-- **Kill Switch**:When enabled, this feature blocks any matching traffic that isn’t sent through the VPN tunnel. This feature has higher priority over other tunnel rules. <!-- Clarified language. -->
+- **Kill Switch**: When enabled, this feature blocks any matching traffic that isn’t sent through the VPN tunnel. This feature has higher priority over other tunnel rules. <!-- Clarified language. -->
 
 ### Travelling To
 

--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -1,14 +1,16 @@
 # VPN Dashboard
 
+GL.iNet routers include a dedicated VPN Dashboard that provides a centralized interface for managing your VPN connections. You can use it to set up and monitor both VPN client and server configurations. The VPN Dashboard allows you to route your internet traffic through encrypted tunnels, helping protect your online privacy, bypass regional restrictions, and access remote networks. 
+
+This guide walks you through the key features of the VPN Dashboard and shows you how to configure, monitor, and optimize your VPN connections.
+
+<!-- A brief introduction allows the user to understand the contents and purpose of this guide. -->
+
 !!! Note
 
     This guide is based on firmware v4.8. If you are using an earlier firmware version, please visit [here](vpn_dashboard_v4.7.md).
 
-Access to web Admin Panel, on the left side -> VPN -> VPN Dashboard. 
-
-This page visually displays VPN status and settings through graphics.
-
-![vpn dashboard unmarked](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/vpn_dashboard_1.png){class="glboxshadow"}
+<!-- Removed "This page visually displays VPN status and settings through graphics." and '[vpn dashboard unmarked.png]' Reason: redundant -->
 
 ### Contents
 
@@ -27,6 +29,10 @@ The VPN dashboard mainly consists of the following parts, marked in the figure b
 ![vpn dashboard marked](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/vpn_dashboard_2.png){class="glboxshadow"}
 
 This guide will introduce to you one by one.
+
+## Navigating to the VPN Dashboard
+
+Access to web Admin Panel, on the left side -> VPN -> VPN Dashboard. 
 
 ## VPN Setup Wizard
 

--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -154,14 +154,14 @@ Click the cog icon next to **Primary Tunnel**, you can rename the tunnel, change
 
 ![tunnel options](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/tunnel_options.png){class="glboxshadow gl-80-desktop"}
 
-- **Services from GL.iNet Use VPN**: When enabled, GoodCloud, DDNS, and rtty services will use VPN tunnels. Note that these services normally need to use the real IP address of the device, enabling this option may affect operation. <!-- Not sure if the original phrasing is intentionally less direct -->
+- **Services from GL.iNet Use VPN**: When enabled, GoodCloud, DDNS, and rtty services will use VPN tunnels. Note that these services normally need to use the real IP address of the device, enabling this option may affect operation. 
 - **Remote Access LAN**: When enabled, devices connected to the VPN tunnel can reach other devices (e.g. computers, printers) on your local network (LAN).
 - **IP Masquerading**: When enabled, your LAN devices' outgoing traffic will be sent through the VPN using router's IP address instead of their own.
-- **MTU (Maximum Transmission Unit)**: Set your own MTU for this tunnel, it determines the largest size of the data packet travelling through your network. Leave as blank to use the system default value. <!-- Consider reccomending values: e.g. "Reccomended 1300-1500 for WireGuard, 1300-1500 for OpenVPN". Also consider adding link to learn more about defining MTU. -->
+- **MTU (Maximum Transmission Unit)**: Set your own MTU for this tunnel, it determines the largest size of the data packet travelling through your network. Leave as blank to use the system default value. <!-- Consider reccomending values: e.g. "Reccomended 1300-1500 for WireGuard, 1300-1500 for OpenVPN". Also consider adding link to learn more about MTU. -->
 
 ## Add Tunnel
 
-Apart from the preset **Primary Tunnel**, you can add tunnels to achieve multiple VPN tunnels. <!-- instance > tunnel for consistency-->
+Apart from the preset **Primary Tunnel**, you can add tunnels to achieve multiple VPN tunnels. <!-- "instances" > "tunnels" for consistency-->
 
 ![add tunnels](https://static.gl-inet.com/docs/router/en/4/interface_guide/vpn_dashboard/add_tunnel.png){class="glboxshadow"}
 
@@ -193,7 +193,7 @@ When there are multiple tunnels, the router transmits traffic in the following o
 
 3. If it still does not match, it will continue to be matched against the next lower priority rule, and so on, until it is matched to the Non-VPN Tunnel with the lowest priority.
 
-You can disable the **Non-VPN Tunnel** if needed. 
+You can disable the Non-VPN Tunnel if needed. 
 
 **Note**: Non-VPN tunnelling ensures that traffic not passing through the above tunnels can still connect to the Internet. If disabled, it will drop any remaining traffic.
 

--- a/docs/interface_guide/vpn_dashboard.md
+++ b/docs/interface_guide/vpn_dashboard.md
@@ -157,7 +157,7 @@ Click the cog icon next to **Primary Tunnel**, you can rename the tunnel, change
 - **Services from GL.iNet Use VPN**: When enabled, GoodCloud, DDNS, and rtty services will use VPN tunnels. Note that these services normally need to use the real IP address of the device, enabling this option may affect operation. <!-- Not sure if the original phrasing is intentionally less direct -->
 - **Remote Access LAN**: When enabled, devices connected to the VPN tunnel can reach other devices (e.g. computers, printers) on your local network (LAN).
 - **IP Masquerading**: When enabled, your LAN devices' outgoing traffic will be sent through the VPN using router's IP address instead of their own.
-- **MTU (Maximum Transmission Unit)**: Set your own MTU for this tunnel, it will override the MTU defined in the configuration file. Leave blank to use the system default value. <!-- Consider reccomending values: e.g. "Reccomended 1300-1500 for WireGuard, 1300-1500 for OpenVPN". Also consider adding link to learn more about defining MTU. -->
+- **MTU (Maximum Transmission Unit)**: Set your own MTU for this tunnel, it determines the largest size of the data packet travelling through your network. Leave blank to use the system default value. <!-- Consider reccomending values: e.g. "Reccomended 1300-1500 for WireGuard, 1300-1500 for OpenVPN". Also consider adding link to learn more about defining MTU. -->
 
 ## Add Tunnel
 


### PR DESCRIPTION
Hi, Hou Yuan here, this is part of my written test for the marketing role.

# Summary of Edits

Most of my edits are to lower the guide’s technical barrier. I understand most of GL.iNet’s customers are technically savvy, but to make the guide more accessible, I tried to clarify concepts and simplify overly technical terms. My rule of thumb is if I, someone with minimal domain knowledge, have to click more than two links to understand the instructions, they need to be edited.

## Clarify Concepts

In the VPN Setup Wizard section, the introduction mentions setting up WireGuard VPN, followed by a list of available VPN clients. Without knowing WireGuard is a protocol, I assumed it was a client and was confused when it was not mentioned in the list of clients. 

To avoid confusion, I introduced WireGuard as a protocol after the clients, distinguishing the two. 

Furthermore, seeing that the “WireGuard Client” page has important follow-up instructions for setting up clients in the Wizard, I direct users to it, rather than presenting it as an optional action.

## Simplify Overly Technical Terms

In Tunnel Settings > Options, I omitted unnecessary jargon and used plain language so users can easily understand the explanations. For example, I omitted “send packets” because it is a unimportant technical detail. I also rephrased 

> resources inside the LAN subnet” 

as 

> devices (e.g. computers, printers) on your local network (LAN)

by providing concrete examples that are easy to understand.

## Maintain Terminology Consistency

I standardized terms to consistently refer to specific actions. For example, there's no longer "traffic rule" in the guide, only "tunnel rule"; no "multiple VPN instances", only "multiple VPN tunnels". Maintaining consistency prevents confusion over semantic changes.

## Format for Easier Navigation

- Bolded all key terms that appear in the figures. This tells the users these terms appear in the UI, allowing easier navigation. 

- I admit the “Navigating to VPN Dashboard” section may be redundant, but when I first opened the guide I was clueless what Admin Panel was referring to.

## Added Introduction Paragraph

A brief introduction puts the guide into context, gives the user an overview of its content and purpose. This addition eases the user into the guide, making it more digestible.


